### PR TITLE
Update apmeter.py

### DIFF
--- a/torchnet/meter/apmeter.py
+++ b/torchnet/meter/apmeter.py
@@ -46,6 +46,7 @@ class APMeter(meter.Meter):
             output = torch.from_numpy(output)
         if not torch.is_tensor(target):
             target = torch.from_numpy(target)
+        target = target.float()    
 
         if weight is not None:
             if not torch.is_tensor(weight):


### PR DESCRIPTION
make sure target is a FloatTensor, otherwise there will be AttributeError: 'torch.LongTensor' object has no attribute 'pow' from line 72:
assert torch.equal(target**2, target), \